### PR TITLE
feat: add FastAPI TODO API scaffolding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "FastAPI TODO",
+  "build": {
+    "dockerfile": "../Dockerfile"
+  },
+  "forwardPorts": [8000],
+  "postCreateCommand": "pip install -r requirements.txt"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - feat/fastapi-todo
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /workspace
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# test
+# FastAPI TODO API
+
+![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)
+
+A minimal TODO API built with FastAPI 0.100+ and Python 3.11. The service keeps data in memory and is optimized for running instantly inside GitHub Codespaces.
+
+## Getting started in Codespaces
+
+1. Create a new Codespace for this repository. The included devcontainer will install dependencies automatically.
+2. Run the development server:
+
+   ```bash
+   uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+   ```
+
+3. Codespaces forwards port **8000** automatically. If prompted, make the port public so you can access it from a browser.
+4. Verify the API is working:
+
+   ```bash
+   curl -s https://<your-codespace-domain>.github.dev/todos
+   ```
+
+## Local development
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+## API specification
+
+| Method | Path                 | Description                            |
+| ------ | -------------------- | -------------------------------------- |
+| GET    | `/todos`             | List all TODO items.                   |
+| POST   | `/todos`             | Create a TODO (`{"title": str}`) with `completed=false`. |
+| PATCH  | `/todos/{id}/toggle` | Toggle completion for a TODO item.     |
+| DELETE | `/todos/{id}`        | Remove a TODO item.                    |
+
+All data is stored in memory and resets when the process restarts.
+
+## Example workflow
+
+```bash
+curl -s -X POST https://<your-codespace-domain>.github.dev/todos \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Write docs"}'
+
+curl -s https://<your-codespace-domain>.github.dev/todos | jq
+
+curl -s -X PATCH https://<your-codespace-domain>.github.dev/todos/1/toggle | jq
+
+curl -i -X DELETE https://<your-codespace-domain>.github.dev/todos/1
+```
+
+## Continuous integration
+
+GitHub Actions runs `pytest` on every push and pull request via [`.github/workflows/ci.yml`](.github/workflows/ci.yml).

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,48 @@
+from fastapi import FastAPI, HTTPException
+
+from .models import TodoCreate, TodoResponse, ToggleResponse
+
+app = FastAPI(title="FastAPI TODO")
+
+
+todos: list[TodoResponse] = []
+_next_id = 1
+
+
+def _get_next_id() -> int:
+    global _next_id
+    current = _next_id
+    _next_id += 1
+    return current
+
+
+def _find_todo(todo_id: int) -> TodoResponse:
+    for todo in todos:
+        if todo.id == todo_id:
+            return todo
+    raise HTTPException(status_code=404, detail="Todo not found")
+
+
+@app.get("/todos", response_model=list[TodoResponse])
+def list_todos() -> list[TodoResponse]:
+    return todos
+
+
+@app.post("/todos", response_model=TodoResponse, status_code=201)
+def create_todo(payload: TodoCreate) -> TodoResponse:
+    todo = TodoResponse(id=_get_next_id(), title=payload.title, completed=False)
+    todos.append(todo)
+    return todo
+
+
+@app.patch("/todos/{todo_id}/toggle", response_model=ToggleResponse)
+def toggle_todo(todo_id: int) -> ToggleResponse:
+    todo = _find_todo(todo_id)
+    todo.completed = not todo.completed
+    return ToggleResponse(id=todo.id, completed=todo.completed)
+
+
+@app.delete("/todos/{todo_id}", status_code=204)
+def delete_todo(todo_id: int) -> None:
+    todo = _find_todo(todo_id)
+    todos.remove(todo)

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+
+class TodoBase(BaseModel):
+    title: str
+    completed: bool = False
+
+
+class TodoCreate(BaseModel):
+    title: str
+
+
+class TodoResponse(TodoBase):
+    id: int
+
+
+class ToggleResponse(BaseModel):
+    id: int
+    completed: bool

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+client = TestClient(app)
+
+
+def test_todo_lifecycle():
+    response = client.get("/todos")
+    assert response.status_code == 200
+    assert response.json() == []
+
+    response = client.post("/todos", json={"title": "Write docs"})
+    assert response.status_code == 201
+    todo = response.json()
+    assert todo["title"] == "Write docs"
+    assert todo["completed"] is False
+    todo_id = todo["id"]
+
+    response = client.patch(f"/todos/{todo_id}/toggle")
+    assert response.status_code == 200
+    assert response.json() == {"id": todo_id, "completed": True}
+
+    response = client.get("/todos")
+    assert response.status_code == 200
+    todos = response.json()
+    assert len(todos) == 1
+    assert todos[0]["completed"] is True
+
+    response = client.delete(f"/todos/{todo_id}")
+    assert response.status_code == 204
+
+    response = client.get("/todos")
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
## Summary
- add a minimal FastAPI TODO application with in-memory storage and REST endpoints
- cover the API lifecycle with FastAPI TestClient-based pytest
- configure Dockerfile, devcontainer, CI workflow, and documentation for Codespaces usage

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi' in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e13ca16ff083339c34dd772148906b